### PR TITLE
trim text attribute of podcast description + script argument example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,10 @@ you can build the docker container and run with
 docker run -it -v '/path/to/opml.opml:/input.opml' -v '/path/to/output_dir:/output' podsnatch
 ```
 
+If you want to limit episodes for download, use `-n` argument. Say, for download last 3 episodes, of each podcast you need specify your command to:
+```bash
+python podsnatch.py --opml <input file> -o <output directory> -n 3
+```
+
 ## Contributing
 PRs welcone!

--- a/podsnatch.py
+++ b/podsnatch.py
@@ -17,10 +17,12 @@ TMP_EXT = '.part'
 class Show:
 
   def __init__(self, outline_element):
-    self.title = outline_element.get('title')
     self.url = (outline_element.get('xmlUrl') or
                 outline_element.get('xmlurl') or
                 None)
+    self.title = (outline_element.get('title') or
+                  outline_element.get('text')[0:50] or
+                  self.url.split('/')[-1])
     self.episode_guids = []
 
   def __str__(self):

--- a/podsnatch.py
+++ b/podsnatch.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
                       help='location to save podcasts')
   parser.add_argument('--number-of-episodes', '-n', dest='ep_cnt',
                       action='store', default=None,
-                      help='path to opml file to import')
+                      help='how many episodes to download. By default - download all')
   args = parser.parse_args()
 
   signal.signal(signal.SIGINT, ctrl_c_handler)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2022.5.18.1
 charset-normalizer==2.0.12
 feedparser==6.0.10
 idna==3.3
-lxml==4.8.0
+lxml==4.9.1
 requests==2.27.1
 sgmllib3k==1.0.0
 tqdm==4.64.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 feedparser==5.2.1
-lxml==4.6.5
+lxml==4.9.1
 requests==2.22.0
 tqdm==4.39.0


### PR DESCRIPTION
Add a maximum length of applied text attribute for 50 symbols. And for edge case - if no text attribute provided - use a last url section.

And provide an example of --number-of-episodes usage in readme